### PR TITLE
Don't complain about long lines with a single default import

### DIFF
--- a/lib/enforce.js
+++ b/lib/enforce.js
@@ -157,12 +157,21 @@ module.exports = {
           if (singleLine) {
             const line = context.getSourceCode().getText(node);
             if (line.length > maxLineLength) {
-              context.report({
-                node,
-                messageId: 'mustSplitLong',
-                data: { maxLineLength, lineLength: line.length },
-                fix: fixer(node, includeSemi),
-              });
+              const hasSingleDefaultImport = (
+                specifiers.length === 1
+                && specifiers[0].type === SPEC_DEFAULT_IMPORT
+              );
+              // There's nothing we can really do about a very long line
+              // that has a single default import (barring a refactor of
+              // the import statement itself) so we'll just ignore it.
+              if (!hasSingleDefaultImport) {
+                context.report({
+                  node,
+                  messageId: 'mustSplitLong',
+                  data: { maxLineLength, lineLength: line.length },
+                  fix: fixer(node, includeSemi),
+                });
+              }
               return;
             }
             if (importedItems > maxItems) {

--- a/test/enforce-vanilla.test.js
+++ b/test/enforce-vanilla.test.js
@@ -190,6 +190,12 @@ ruleTester.run('enforce', rule, {
         forceSingleLine: false,
       }],
     },
+    {
+      code: `import ${repeatString('a', 73)} from './${repeatString('a', 73)}';`,
+      options: [{
+        'max-len': 140,
+      }],
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
An import line such as
```typescript
import aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa from '../aaaaaaaaaaaaaaa/aaaaaaaaaaaaaaa/aaaaaaaaaaaaaaa';
```
can't necessarily be split at all, let's not complain about that.