### PR TITLE
Fix namespace imports being removed when the max-len is exceeded

### DIFF
--- a/lib/enforce.js
+++ b/lib/enforce.js
@@ -1,5 +1,6 @@
 const SPEC_IMPORT = 'ImportSpecifier';
 const SPEC_DEFAULT_IMPORT = 'ImportDefaultSpecifier';
+const SPEC_NAMESPACE_IMPORT = 'ImportNamespaceSpecifier';
 
 const applyAliasAndType = (currentNode) => {
   const localName = currentNode.local.name;
@@ -161,10 +162,28 @@ module.exports = {
                 specifiers.length === 1
                 && specifiers[0].type === SPEC_DEFAULT_IMPORT
               );
+
+              const hasNamespaceImport = (
+                specifiers.length === 1
+                && specifiers[0].type === SPEC_NAMESPACE_IMPORT
+              );
+
+              const hasSingleDefaultAndNamespaceImport = (
+                specifiers.length === 2
+                && specifiers[0].type === SPEC_DEFAULT_IMPORT
+                && specifiers[1].type === SPEC_NAMESPACE_IMPORT
+              );
+
               // There's nothing we can really do about a very long line
-              // that has a single default import (barring a refactor of
-              // the import statement itself) so we'll just ignore it.
-              if (!hasSingleDefaultImport) {
+              // that has a single default import, a namespace import or
+              // a single default import with a namespace import (barring
+              // a refactor of the import statement itself) so we'll just
+              // ignore it.
+              if (!(
+                hasSingleDefaultImport
+                || hasNamespaceImport
+                || hasSingleDefaultAndNamespaceImport
+              )) {
                 context.report({
                   node,
                   messageId: 'mustSplitLong',

--- a/test/enforce-vanilla.test.js
+++ b/test/enforce-vanilla.test.js
@@ -46,6 +46,9 @@ ruleTester.run('enforce', rule, {
       code: "import * as test from './test'",
     },
     {
+      code: "import a, * as b from './test'",
+    },
+    {
       code: "import './test.css'",
     },
     {
@@ -194,6 +197,18 @@ ruleTester.run('enforce', rule, {
       code: `import ${repeatString('a', 73)} from './${repeatString('a', 73)}';`,
       options: [{
         'max-len': 140,
+      }],
+    },
+    {
+      code: `import * as test from './${repeatString('a', 50)}'`,
+      options: [{
+        'max-len': 50,
+      }],
+    },
+    {
+      code: `import a, * as b from './${repeatString('a', 50)}'`,
+      options: [{
+        'max-len': 50,
       }],
     },
   ],


### PR DESCRIPTION
This fixes an issue where a namespace import is removed by the fixer when it exceeds the configured max-len which leads to invalid imports.

I've looked around and there are only two valid namespace imports:

1. `import * as a from 'dependency`
1. `import a, * as b from 'dependency`

### Reproduction

This problem can be reproduced using the following configuration:

```json
{
  "rules": {
    "import-newlines-enforce": [
      "error",
      {
        "max-len": 120
      }
    ],
  } 
}
```

This is the namespace import before the fix: 

```ts
import * as namespaceimport from 'some-dependency/with_a_very_long_import_path_that_exceeds_the_configured_max-len_and_breaks_when_fixing';
```

This is the namespace import after the fix:

```ts
import from 'some-dependency/with_a_very_long_import_path_that_exceeds_the_configured_max-len_and_breaks_when_fixing';
```

## Expected behavior

The expected behavior is that it keeps the import as is, like how it is done for the single default import that is exceeding the configured max-len.

## Workaround

There is a workaround for this and that is to simply disable the rule for certain imports. This is however not a great solution.

```ts
// eslint-disable-next-line import-newlines/enforce
import * as namespaceimport from 'some-dependency/with_a_very_long_import_path_that_exceeds_the_configured_max-len_and_breaks_when_fixing';
```
