### PR TITLE
Added `allowBlankLines` option to not error when blank lines are encountered

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ and the result would fit within the configured `max-length`. This can be set to 
 to be able to break imports up to multiple lines without the plugin reporting an error and offering
 an autofix.
 
+#### `allowBlankLines` [boolean] (default: `false`)
+
+Allows imports to contain blank lines. Blank lines will still be removed when applying an autofix for any other reason, but if this option is set to `true` they won't cause the plugin to report an error.
+
 ### Testing
 
 Tests can be run via `npm run test`, make sure these pass after every change. Be sure to add tests

--- a/lib/enforce.js
+++ b/lib/enforce.js
@@ -174,6 +174,7 @@ const DEFAULT_MAX_LENGTH = Infinity;
 const MIN_MAX_LENGTH = 17;
 const DEFAULT_SEMICOLON = true;
 const DEFAULT_FORCE_SINGLE_LINE = true;
+const DEFAULT_ALLOW_BLANK_LINES = false;
 
 module.exports = {
   meta: {
@@ -207,6 +208,9 @@ module.exports = {
               forceSingleLine: {
                 type: 'boolean',
               },
+              allowBlankLines: {
+                type: 'boolean',
+              },
             },
           },
         },
@@ -234,6 +238,7 @@ module.exports = {
     // Legacy default, prior to a refactoring this value was not set for array type configurations
     let includeSemi = false;
     let forceSingleLine = DEFAULT_FORCE_SINGLE_LINE;
+    let allowBlankLines = DEFAULT_ALLOW_BLANK_LINES;
     const firstOption = context.options[0];
     if (typeof firstOption === 'object') {
       // Supported object-based configuration
@@ -242,6 +247,7 @@ module.exports = {
         'max-len': maxLineLength = DEFAULT_MAX_LENGTH,
         semi: includeSemi = DEFAULT_SEMICOLON,
         forceSingleLine = DEFAULT_FORCE_SINGLE_LINE,
+        allowBlankLines = DEFAULT_ALLOW_BLANK_LINES,
       } = firstOption);
     } else {
       // Legacy array-based configuration
@@ -278,7 +284,7 @@ module.exports = {
           const previousEndLine = previousItem.loc.end.line;
           const currentStartLine = currentItem.loc.start.line;
           const lineDifference = currentStartLine - previousEndLine;
-          if (!blankLinesReported && lineDifference > 1) {
+          if (!allowBlankLines && !blankLinesReported && lineDifference > 1) {
             context.report({
               node,
               messageId: 'noBlankBetween',
@@ -320,16 +326,18 @@ module.exports = {
             return;
           }
 
-          // One item per line + line with import + line with from
-          const expectedLineCount = importedItems + 2;
-          if (importLineCount !== expectedLineCount) {
-            context.report({
-              node,
-              messageId: 'limitLineCount',
-              data: { expectedLineCount, importLineCount },
-              fix: fixer(node, includeSemi),
-            });
-            return;
+          if (!allowBlankLines) {
+            // One item per line + line with import + line with from
+            const expectedLineCount = importedItems + 2;
+            if (importLineCount !== expectedLineCount) {
+              context.report({
+                node,
+                messageId: 'limitLineCount',
+                data: { expectedLineCount, importLineCount },
+                fix: fixer(node, includeSemi),
+              });
+              return;
+            }
           }
 
           if (forceSingleLine && importedItems <= maxItems) {

--- a/test/enforce-typescript.test.js
+++ b/test/enforce-typescript.test.js
@@ -213,6 +213,38 @@ import App from './App'
 }`,
       options: [],
     },
+    {
+      code: "import type { \na,\n\nb,\n\n\nc,\n\n\nd,\n\n\n\ne\n} from './test'",
+      output: "import type {\na,\nb,\nc,\nd,\ne\n} from './test'",
+      options: [{
+        items: 4,
+        allowBlankLines: true,
+      }],
+    },
+    {
+      code: "import type { a,\n\n\nb } from './test'",
+      output: "import type {\na,\nb\n} from './test'",
+      options: [{
+        items: 1,
+        allowBlankLines: true,
+      }],
+    },
+    {
+      code: "import type {\n\na,\nb\n\n\n} from './test'",
+      output: "import type {\na,\nb\n} from './test'",
+      options: [{
+        items: 1,
+        allowBlankLines: true,
+      }],
+    },
+    {
+      code: "import type {\na, b, c\n} from './test'",
+      output: "import type {\na,\nb,\nc\n} from './test'",
+      options: [{
+        items: 1,
+        allowBlankLines: true,
+      }],
+    },
   ],
 
   invalid: [

--- a/test/enforce-vanilla.test.js
+++ b/test/enforce-vanilla.test.js
@@ -250,6 +250,38 @@ import App from './App'
         'max-len': 50,
       }],
     },
+    {
+      code: "import { \na,\n\nb,\n\n\nc,\n\n\nd,\n\n\n\ne\n} from './test'",
+      output: "import {\na,\nb,\nc,\nd,\ne\n} from './test'",
+      options: [{
+        items: 4,
+        allowBlankLines: true,
+      }],
+    },
+    {
+      code: "import { a,\n\n\nb } from './test'",
+      output: "import {\na,\nb\n} from './test'",
+      options: [{
+        items: 1,
+        allowBlankLines: true,
+      }],
+    },
+    {
+      code: "import {\n\na,\nb\n\n\n} from './test'",
+      output: "import {\na,\nb\n} from './test'",
+      options: [{
+        items: 1,
+        allowBlankLines: true,
+      }],
+    },
+    {
+      code: "import {\na, b, c\n} from './test'",
+      output: "import {\na,\nb,\nc\n} from './test'",
+      options: [{
+        items: 1,
+        allowBlankLines: true,
+      }],
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
Resolves #16 

This PR adds an `allowBlankLines` configuration option which suppresses the `noBlankBetween` and `limitLineCount` errors, in order to allow import statements that contain one or more blank lines. It does not change the autofix behaviour at all, and defaults to `false` to preserve existing default behaviour.

The only tests I've added are that the existing tests for `noBlankBetween` and `limitLineCount` will be treated as valid if `allowBlankLines` is set to `true`.